### PR TITLE
Fix generating CoordinatePairs of double the specified size.

### DIFF
--- a/coordinate_pair.go
+++ b/coordinate_pair.go
@@ -21,7 +21,7 @@ func SortCoordinatePairs(cp []CoordinatePair) {
 func SlicesToCoordinatePairs(x, y []float64) []CoordinatePair {
 	cp := make([]CoordinatePair, len(x))
 	for i := 0; i < len(x); i++ {
-		cp = append(cp, CoordinatePair{X: x[i], Y: y[i]})
+		cp[i] = CoordinatePair{X: x[i], Y: y[i]}
 	}
 	return cp
 }


### PR DESCRIPTION
Whenever this function is called, it generates a slice two
times bigger than is requested. This is caused by creating
a slice using `make(type, len)` call, which populates the
slice with zero based type values and then additionally appends
valid coordinate pairs.

As a result, when linearly interpolating some values, go would
reach max recursion depth.